### PR TITLE
(patch)(fix) wrong memory uses warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-xsecurity",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-xsecurity",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "bin": {
         "nestjs-xsecurity": "dist/cli/bin/install.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-xsecurity",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Security middleware for NestJS applications with token validation and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixed an issue where this package is showing `XSecurity: High memory usage detected. Forcing cleanup...` message based on wrong value
